### PR TITLE
Adds AMD support

### DIFF
--- a/throbber.js
+++ b/throbber.js
@@ -9,8 +9,15 @@
 
 /*global Image, Throbber:true*/
 
-(function( window ) {
-
+(function (window, factory) {
+    if (typeof exports === "object" && exports) {
+        module.exports = factory; // CommonJS
+    } else if (typeof define === "function" && define.amd) {
+        define(function(){return factory}); // AMD
+    } else {
+        window.Throbber = factory; // <script>
+    }
+}(this, (function () {
     var document = window.document,
 
         M = Math,
@@ -101,7 +108,8 @@
 
 
     // Throbber constructor
-    Throbber = function( options ) {
+    var Throbber = function( options ) {
+    if (this == window) return;
 
         var elem = this.elem = document.createElement('canvas'),
             scope = this;
@@ -271,5 +279,7 @@
             }
         }
     };
+    
+    return Throbber;
 
-}( this ));
+}())));

--- a/throbber.js
+++ b/throbber.js
@@ -126,7 +126,8 @@
             color: '#fff',      // color of the spinner, can be any CSS compatible value
             fade: 300,          // duration of fadein/out when calling .start() and .stop()
             fallback: false,    // a gif fallback for non-supported browsers
-            alpha: 1            // global alpha, can be defined using rgba as color or separatly
+            alpha: 1,           // global alpha, can be defined using rgba as color or separatly
+            className: ''       // class name for the throbber element
         };
 
         /*
@@ -248,6 +249,9 @@
 
             // copy the amount of lines into steps
             this.step = o.lines;
+
+            // add the class name to the elem
+            this.elem.className = o.className;
 
             return this;
         },

--- a/throbber.js
+++ b/throbber.js
@@ -109,7 +109,6 @@
 
     // Throbber constructor
     var Throbber = function( options ) {
-    if (this == window) return;
 
         var elem = this.elem = document.createElement('canvas'),
             scope = this;


### PR DESCRIPTION
This pull request adds support for AMD/CommonJS. It detects the presents of module.exports or define and uses them if they exist. If neither of those exist, Throbber is added to the window object just like before.

I created this change because I'm using throbber.js in a project that uses require.js, and needed to be able to use it properly with require instead of creating a new object in window.
