### PR TITLE
Add missing Canvas2DRenderingContext.restore() call

### DIFF
--- a/throbber.js
+++ b/throbber.js
@@ -96,6 +96,7 @@
 
                 ctx.rotate( rd * ( 360/o.lines/( 20-o.rotationspeed*2 ) ) * M.PI/180 ); //rotate in origin
                 _restore( ctx, size, true );
+                ctx.restore();
             }
         };
 


### PR DESCRIPTION
When this code is used in QtWebKit (and possibly other implementations), calling ctx.save() without a corresponding ctx.restore() call results in a resource leak internally.

This manifests itself as 'QPainter::end: Painter ended with N saved states' warnings and continually increasing memory usage.
