### PR TITLE
Fix memory leak and improve performance (closes #8)

### DIFF
--- a/README
+++ b/README
@@ -4,17 +4,17 @@ throbber.js
 
 Background: I needed a really nice looking spinner that works on top of images. Even though
 there are quite a few javascript solutions available, none of them looked the way I wanted.
-So I created my own. And it went pretty well, so I github'd and MIT'd it. 
+So I created my own. And it went pretty well, so I github'd and MIT'd it.
 
 Demo: http://aino.github.io/throbber.js/
 
-Throbber uses canvas and animationFrame to create the animation and graphics. 
-It does not fiddle with VML for IE, instead you can pass a fallback gif for all browsers 
+Throbber uses canvas and animationFrame to create the animation and graphics.
+It does not fiddle with VML for IE, instead you can pass a fallback gif for all browsers
 that do not support canvas. It adjusts itself for retina resolutions.
 
 It’s a mere 1.2k gzipped & minified
 
-Install using Bower: 
+Install using Bower:
 
   bower install throbber.js
 
@@ -34,7 +34,7 @@ Creates a 20x20 pixels throbber:
   loader.start();
 
 Creates a throbber with options:
-  
+
   var loader = Throbber({ size:40, padding: 30 });
 
 --
@@ -63,3 +63,10 @@ fps                   // frames per second
 padding               // diameter of clipped inner area
 strokewidth           // width of the lines
 lines                 // number of lines (~size/2+4)
+
+## Changelog
+
+### 0.0.3
+
+* Performance improved by stoping loops when throbbers stop.
+* Fix memory leak due to saving canvas contexts without restore

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "throbber.js",
   "main": "throbber.js",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/aino/throbber.js",
   "authors": [
     "Aino <http://aino.com>"


### PR DESCRIPTION
Fixes a memory leak due to calling ctx.save() without a corresponding
restore.

Improve performance by allowing Throbber.loop() to unschedule when
throbber stops, rescheduling when throbber is started.

Similarly, allow tick() to stop when no active throbbers, restarting
when a throbber is started.
